### PR TITLE
add dependency installation step in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 # install dependencies
 $ go get github.com/Sirupsen/logrus
 $ go get github.com/timest/gomanuf
+$ go get github.com/google/gopacket
 
 # build
 $ go build

--- a/README.md
+++ b/README.md
@@ -20,10 +20,17 @@
  
 ### Usage: ###
 
-```go
-$ go build main
+```sh
+# install dependencies
+$ go get github.com/Sirupsen/logrus
+$ go get github.com/timest/gomanuf
+
+# build
+$ go build
+
+# execute
 $ sudo ./main  
-or 
+# or
 $ sudo ./main -I en0
 ```
 


### PR DESCRIPTION
It adds in README.md the steps to follow in order to install the depencencies for the project.
If these extra steps are not followed, the `go build` command throws an error if the depencencies are not yet installed in the building environment.